### PR TITLE
Allow plain 'array' dtype #4

### DIFF
--- a/scratch.js
+++ b/scratch.js
@@ -4,12 +4,17 @@ var ndarray = require("ndarray")
 var ops = require("ndarray-ops")
 var pool = require("typedarray-pool")
 
+function poolMalloc(sz, dtype) {
+  if (dtype==='array') {
+    return new Array(sz)
+  } else {
+    return pool.malloc(sz,dtype)
+  }
+}
+
 function clone(array) {
   var dtype = array.dtype
-  if(dtype === "generic" || dtype === "array") {
-    dtype = "double"
-  }
-  var data = pool.malloc(array.size, dtype)
+  var data = poolMalloc(array.size, dtype)
   var result = ndarray(data, array.shape)
   ops.assign(result, array)
   return result
@@ -26,7 +31,7 @@ function malloc(shape, dtype) {
     stride[i] = sz
     sz *= shape[i]
   }
-  return ndarray(pool.malloc(sz, dtype), shape, stride, 0)
+  return ndarray(poolMalloc(sz, dtype), shape, stride, 0)
 }
 exports.malloc = malloc
 
@@ -49,7 +54,7 @@ function zeros(shape, dtype) {
     stride[i] = sz
     sz *= shape[i]
   }
-  var buf = pool.malloc(sz, dtype)
+  var buf = poolMalloc(sz, dtype)
   for(var i=0; i<sz; ++i) {
     buf[i] = 0
   }
@@ -68,7 +73,7 @@ function ones(shape, dtype) {
     stride[i] = sz
     sz *= shape[i]
   }
-  var buf = pool.malloc(sz, dtype)
+  var buf = poolMalloc(sz, dtype)
   for(var i=0; i<sz; ++i) {
     buf[i] = 1
   }
@@ -88,7 +93,7 @@ function eye(shape, dtype) {
     stride[i] = sz
     sz *= shape[i]
   }
-  var buf = pool.malloc(sz, dtype)
+  var buf = poolMalloc(sz, dtype)
   for(i=0; i<sz; ++i) {
     buf[i] = 0
   }

--- a/scratch.js
+++ b/scratch.js
@@ -14,6 +14,9 @@ function poolMalloc(sz, dtype) {
 
 function clone(array) {
   var dtype = array.dtype
+  if(array.dtype === "generic") {
+    dtype = 'double'
+  }
   var data = poolMalloc(array.size, dtype)
   var result = ndarray(data, array.shape)
   ops.assign(result, array)

--- a/test/test.js
+++ b/test/test.js
@@ -1,60 +1,65 @@
 "use strict"
 
 var pool = require("../scratch.js")
+var tape = require('tape')
 
-require("tape")("ndarray-scratch", function(t) {
+var dtypes = ['double', 'array', 'float']
 
-  var i,j,k
+tape("ndarray-scratch", function(t) {
+  dtypes.forEach(function(dtype) {
 
-  var x = pool.malloc([10,10])
+    var i,j,k
 
-  t.same(x.shape.slice(), [10,10])
-  t.same(x.stride.slice(), [10,1])
-  t.assert(x.data.length >= 10*10)
+    var x = pool.malloc([10,10], dtype)
 
-  var y = pool.clone(x)
-  t.same(x.shape, y.shape)
-  t.same(x.stride, y.stride)
-  t.same(x.data.length, y.data.length)
-  t.same(x.dtype, y.dtype)
+    t.same(x.shape.slice(), [10,10])
+    t.same(x.stride.slice(), [10,1])
+    t.assert(x.data.length >= 10*10)
 
-  pool.free(x)
-  pool.free(y)
+    var y = pool.clone(x)
+    t.same(x.shape, y.shape)
+    t.same(x.stride, y.stride)
+    t.same(x.data.length, y.data.length)
+    t.same(x.dtype, y.dtype)
 
-  var zeros = pool.zeros([10,10])
-  t.same(zeros.shape, x.shape)
+    pool.free(x)
+    pool.free(y)
 
-  for(i=0; i<10; i++) {
-    for(j=0; j<10; j++) {
-      t.equal(zeros.get(i,j), 0)
-    }
-  }
+    var zeros = pool.zeros([10,10])
+    t.same(zeros.shape, x.shape)
 
-  var ones = pool.ones([10,10])
-  t.same(ones.shape, x.shape)
-  for(i=0; i<10; i++) {
-    for(j=0; j<10; j++) {
-      t.equal(ones.get(i,j), 1)
-    }
-  }
-
-  var eye = pool.eye([10,10])
-  t.same(eye.shape, x.shape)
-  for(i=0; i<10; i++) {
-    for(j=0; j<10; j++) {
-      t.equal(eye.get(i,j), i===j ? 1 : 0)
-    }
-  }
-
-  var eye3 = pool.eye([3,4,5])
-  t.same(eye3.shape, [3,4,5])
-  for(i=0; i<3; i++) {
-    for(j=0; j<4; j++) {
-      for(k=0; k<5; k++) {
-        t.equal(eye3.get(i,j,k), (i===j && j===k) ? 1 : 0)
+    for(i=0; i<10; i++) {
+      for(j=0; j<10; j++) {
+        t.equal(zeros.get(i,j), 0)
       }
     }
-  }
 
+    var ones = pool.ones([10,10])
+    t.same(ones.shape, x.shape)
+    for(i=0; i<10; i++) {
+      for(j=0; j<10; j++) {
+        t.equal(ones.get(i,j), 1)
+      }
+    }
+
+    var eye = pool.eye([10,10])
+    t.same(eye.shape, x.shape)
+    for(i=0; i<10; i++) {
+      for(j=0; j<10; j++) {
+        t.equal(eye.get(i,j), i===j ? 1 : 0)
+      }
+    }
+
+    var eye3 = pool.eye([3,4,5])
+    t.same(eye3.shape, [3,4,5])
+    for(i=0; i<3; i++) {
+      for(j=0; j<4; j++) {
+        for(k=0; k<5; k++) {
+          t.equal(eye3.get(i,j,k), (i===j && j===k) ? 1 : 0)
+        }
+      }
+    }
+
+  })
   t.end()
 })


### PR DESCRIPTION
This PR bypasses pool.malloc if the dtype is `array` and returns simply `new Array(sz)`. Some modules require (optional) allocation of output. This makes it consistent and less surprising to allocate storage of the same dtype without extra gymnastics.
