### PR TITLE
Correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pool.free(x)
 # API
 
 ```javascript
-var pool = require("ndarray-pool")
+var pool = require("ndarray-scratch")
 ```
 
 ### `pool.malloc(shape[, dtype])`


### PR DESCRIPTION
This updates the readme with `require('ndarray-scratch')` instead of `require('ndarray-pool')`.
